### PR TITLE
Improve remote reference detection

### DIFF
--- a/tests/data/externalClean.svg
+++ b/tests/data/externalClean.svg
@@ -2,6 +2,9 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve">
 <rect x="0" y="0" width="1000" height="1000"></rect>
 <rect x="0" y="0" width="1000" height="1000"></rect>
+<rect x="0" y="0" width="1000" height="1000"></rect>
+<rect x="0" y="0" width="1000" height="1000"></rect>
+<rect x="0" y="0" width="1000" height="1000"></rect>
 <rect fill="url('/benis.svg')" x="0" y="0" width="1000" height="1000"></rect>
 <rect fill="url('#benis.svg')" x="0" y="0" width="1000" height="1000"></rect>
 </svg>

--- a/tests/data/externalTest.svg
+++ b/tests/data/externalTest.svg
@@ -3,6 +3,9 @@
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve">
 <rect fill="url('http://example.com/benis.svg')" x="0" y="0" width="1000" height="1000"></rect>
 <rect fill="url('https://example.com/benis.svg')" x="0" y="0" width="1000" height="1000"></rect>
+<rect fill="  url(  ' https://example.com/benis.svg '  ) " x="0" y="0" width="1000" height="1000"></rect>
+<rect fill="url('ftp://192.168.2.1/benis.svg')" x="0" y="0" width="1000" height="1000"></rect>
+<rect fill="url('//example.com/benis.svg')" x="0" y="0" width="1000" height="1000"></rect>
 <rect fill="url('/benis.svg')" x="0" y="0" width="1000" height="1000"></rect>
 <rect fill="url('#benis.svg')" x="0" y="0" width="1000" height="1000"></rect>
 </svg>


### PR DESCRIPTION
This change aims to address some shortcomings of the current remote reference checking method that allows `//example.com/folder` or `ftp://…` links to go through for example. I'm more confident using this sanitizer in my project with these changes.

Tried to follow the formatting of the file, but if something's off with that or the way this was done please let me know.