### PR TITLE
Allow setting xml options and another bugfix

### DIFF
--- a/tests/SanitizerTest.php
+++ b/tests/SanitizerTest.php
@@ -179,6 +179,9 @@ class SanitizerTest extends PHPUnit_Framework_TestCase
         $this->assertXmlStringEqualsXmlString($expected, $cleanData);
     }
 
+    /**
+     * Test setXMLOptions and minifying works as expected
+     */
     public function testMinifiedOptions()
     {
         $this->class->minify(true);

--- a/tests/SanitizerTest.php
+++ b/tests/SanitizerTest.php
@@ -178,4 +178,15 @@ class SanitizerTest extends PHPUnit_Framework_TestCase
 
         $this->assertXmlStringEqualsXmlString($expected, $cleanData);
     }
+
+    public function testMinifiedOptions()
+    {
+        $this->class->minify(true);
+        $this->class->removeXMLTag(true);
+        $this->class->setXMLOptions(0);
+
+        $input = '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><title>chevron-double-down</title><path d="M4 11.73l.68-.73L12 17.82 19.32 11l.68.73-7.66 7.13a.5.5 0 0 1-.68 0z"/><path d="M4 5.73L4.68 5 12 11.82 19.32 5l.68.73-7.66 7.13a.5.5 0 0 1-.68 0z"/></svg>';
+        $output = $this->class->sanitize($input);
+        $this->assertEquals($input, $output);
+    }
 }


### PR DESCRIPTION
I noticed that the sanitizer changed this:

```svg
<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><title>chevron-double-down</title><path d="M4 11.73l.68-.73L12 17.82 19.32 11l.68.73-7.66 7.13a.5.5 0 0 1-.68 0z"/><path d="M4 5.73L4.68 5 12 11.82 19.32 5l.68.73-7.66 7.13a.5.5 0 0 1-.68 0z"/></svg>
```

into this:

```svg
<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"> <title>chevron-double-down</title> <path d="M4 11.73l.68-.73L12 17.82 19.32 11l.68.73-7.66 7.13a.5.5 0 0 1-.68 0z"></path> <path d="M4 5.73L4.68 5 12 11.82 19.32 5l.68.73-7.66 7.13a.5.5 0 0 1-.68 0z"></path> </svg>
```

I wanted to remove the extra spaces between elements and allow self-closing tags (ie `<path />`).

This pull-request fixes both, by adding a `setXMLOptions` method and by only calling `resetInternal` before sanitizing. Backwards-compatibility has been maintained.

I've also cleaned up some code formatting to make it a bit easier to read.