### PR TITLE
Adding standalone scanner

### DIFF
--- a/src/Sanitizer.php
+++ b/src/Sanitizer.php
@@ -352,7 +352,7 @@ class Sanitizer
             ))) {
                 $element->removeAttributeNS( 'http://www.w3.org/1999/xlink', 'href' );
                 $this->xmlIssues[] = array(
-                    'message' => 'Suspicious attribute \'' . $attrName . '\'',
+                    'message' => 'Suspicious attribute \'href\'',
                     'line' => $element->getLineNo(),
 		);
 

--- a/src/Sanitizer.php
+++ b/src/Sanitizer.php
@@ -372,7 +372,7 @@ class Sanitizer
         if (preg_match(self::SCRIPT_REGEX, $href) === 1) {
             $element->removeAttribute('href');
             $this->xmlIssues[] = array(
-                'message' => 'Suspicious attribute \'' . $attrName . '\'',
+                'message' => 'Suspicious attribute \'href\'',
                 'line' => $element->getLineNo(),
             );
         }

--- a/src/Sanitizer.php
+++ b/src/Sanitizer.php
@@ -62,6 +62,11 @@ class Sanitizer
     protected $xmlOptions = LIBXML_NOEMPTYTAG;
 
     /**
+     * @var array
+     */
+    protected $xmlIssues = array();
+
+    /**
      *
      */
     function __construct()
@@ -155,6 +160,14 @@ class Sanitizer
     }
 
     /**
+     * Get 
+     */
+    public function getXmlIssues() {
+         return $this->xmlIssues;
+    }
+
+
+    /**
      * Sanitize the passed string
      *
      * @param string $dirty
@@ -217,6 +230,9 @@ class Sanitizer
 
         // Suppress the errors because we don't really have to worry about formation before cleansing
         libxml_use_internal_errors(true);
+ 
+        // Reset array of altered XML
+        $this->xmlIssues = array();
     }
 
     /**
@@ -257,6 +273,10 @@ class Sanitizer
             // If the tag isn't in the whitelist, remove it and continue with next iteration
             if (!in_array(strtolower($currentElement->tagName), $this->allowedTags)) {
                 $currentElement->parentNode->removeChild($currentElement);
+                $this->xmlIssues[] = array(
+                    'message' => 'Suspicious tag \'' . $currentElement->tagName . '\'',
+                    'line' => $currentElement->getLineNo(),
+		);
                 continue;
             }
 
@@ -269,6 +289,10 @@ class Sanitizer
             if (strtolower($currentElement->tagName) === 'use') {
                 if ($this->isUseTagDirty($currentElement)) {
                     $currentElement->parentNode->removeChild($currentElement);
+                    $this->xmlIssues[] = array(
+                        'message' => 'Suspicious \'' . $currentElement->tagName . '\'',
+			'line' => $currentElement->getLineNo(),
+                    );
                     continue;
                 }
             }
@@ -288,7 +312,12 @@ class Sanitizer
 
             // Remove attribute if not in whitelist
             if (!in_array(strtolower($attrName), $this->allowedAttrs) && !$this->isAriaAttribute(strtolower($attrName)) && !$this->isDataAttribute(strtolower($attrName))) {
+
                 $element->removeAttribute($attrName);
+                $this->xmlIssues[] = array(
+                    'message' => 'Suspicious attribute \'' . $attrName . '\'',
+                    'line' => $element->getLineNo(),
+		);
             }
 
             // Do we want to strip remote references?
@@ -296,6 +325,10 @@ class Sanitizer
                 // Remove attribute if it has a remote reference
                 if (isset($element->attributes->item($x)->value) && $this->hasRemoteReference($element->attributes->item($x)->value)) {
                     $element->removeAttribute($attrName);
+                    $this->xmlIssues[] = array(
+                        'message' => 'Suspicious attribute \'' . $attrName . '\'',
+                        'line' => $element->getLineNo(),
+		    );
                 }
             }
         }
@@ -318,7 +351,13 @@ class Sanitizer
                 'data:image/pjp', // PJPEG
             ))) {
                 $element->removeAttributeNS( 'http://www.w3.org/1999/xlink', 'href' );
-            }
+                $this->xmlIssues[] = array(
+                    'message' => 'Suspicious attribute \'' . $attrName . '\'',
+                    'line' => $element->getLineNo(),
+		);
+
+
+           }
         }
     }
 
@@ -332,6 +371,10 @@ class Sanitizer
         $href = $element->getAttribute('href');
         if (preg_match(self::SCRIPT_REGEX, $href) === 1) {
             $element->removeAttribute('href');
+            $this->xmlIssues[] = array(
+                'message' => 'Suspicious attribute \'' . $attrName . '\'',
+                'line' => $element->getLineNo(),
+            );
         }
     }
 

--- a/svg-scanner.php
+++ b/svg-scanner.php
@@ -1,3 +1,4 @@
+#!/usr/bin/env php
 <?php
 
 /*

--- a/svg-scanner.php
+++ b/svg-scanner.php
@@ -13,34 +13,6 @@ require_once( __DIR__ . '/src/data/AllowedAttributes.php' );
 require_once( __DIR__ . '/src/data/AllowedTags.php' );
 require_once( __DIR__ . '/src/Sanitizer.php' );
 
-/*
- * We need to allow certain extra attributes, so
- * extend the AllowedAttributes class to enable that.
- */
-class AllowedAttributesCustom extends enshrined\svgSanitize\data\AllowedAttributes {
-	public static function getAttributes() {
-		$default_allowed_attributes =
-			parent::getAttributes();
-
-		return array_merge(
-			array(
-				// The extra attributes allowable
-				'version',
-				'enable-background',
-				'cy',
-				'cx',
-				'rx',
-				'ry',
-				'fill',
-				'y',
-				'x',
-				'space',
-			),
-			$default_allowed_attributes
-		);
-	}
-}
-
 
 /*
  * Print array as JSON and then
@@ -115,10 +87,6 @@ if ( empty( $files_to_scan ) ) {
  * and to remove remote references.
  */
 $sanitizer = new enshrined\svgSanitize\Sanitizer();
-
-$sanitizer->setAllowedAttrs(
-	new AllowedAttributesCustom()
-);
 
 $sanitizer->removeRemoteReferences( true );
 

--- a/svg-scanner.php
+++ b/svg-scanner.php
@@ -107,9 +107,14 @@ foreach( $files_to_scan as $file_name ) {
 	if ( false === $svg_file ) {
 		$results['totals']['errors']++;
 
-		$results[ 'files' ][ $file_name ][] = array(
-			'status' => false,
-			'issues' => 'File specified could not be read (' . $file_name . ')',
+		$results['files'][ $file_name ][] = array(
+			'errors' => 1,
+			'messages' => array(
+				array(
+					'message' => 'File specified could not be read (' . $file_name . ')',
+					'line' => null,
+				),
+			),
 		);
 
 		continue;
@@ -129,6 +134,26 @@ foreach( $files_to_scan as $file_name ) {
 		$results['files'][ $file_name ] = array(
 			'errors' => 0,
 			'messages' => array()
+		);
+	}
+
+	/*
+	 * Could not sanitize the file.
+	 */
+	else if (
+		( '' === $sanitize_status ) ||
+		( false === $sanitize_status )
+	) {
+		$results['totals']['errors']++;
+
+		$results['files'][ $file_name ] = array(
+			'errors' => 1,
+			'messages' => array(
+				array(
+					'message' => 'Unable to sanitize file \'' . $file_name . '\'' ,
+					'line' => null,
+				)
+			),
 		);
 	}
 

--- a/svg-scanner.php
+++ b/svg-scanner.php
@@ -1,0 +1,193 @@
+<?php
+
+/*
+ * Simple program that uses svg-sanitizer
+ * to find issues in files specified on the
+ * command line, and prints a JSON output with
+ * the issues found on exit.
+ */
+
+require_once( __DIR__ . '/src/data/AttributeInterface.php' );
+require_once( __DIR__ . '/src/data/TagInterface.php' );
+require_once( __DIR__ . '/src/data/AllowedAttributes.php' );
+require_once( __DIR__ . '/src/data/AllowedTags.php' );
+require_once( __DIR__ . '/src/Sanitizer.php' );
+
+/*
+ * We need to allow certain extra attributes, so
+ * extend the AllowedAttributes class to enable that.
+ */
+class AllowedAttributesCustom extends enshrined\svgSanitize\data\AllowedAttributes {
+	public static function getAttributes() {
+		$default_allowed_attributes =
+			parent::getAttributes();
+
+		return array_merge(
+			array(
+				// The extra attributes allowable
+				'version',
+				'enable-background',
+				'cy',
+				'cx',
+				'rx',
+				'ry',
+				'fill',
+				'y',
+				'x',
+				'space',
+			),
+			$default_allowed_attributes
+		);
+	}
+}
+
+
+/*
+ * Print array as JSON and then
+ * exit program with a particular
+ * exit-code.
+ */
+
+function sysexit(
+	$results,
+	$status
+) {
+	echo json_encode(
+		$results,
+		JSON_PRETTY_PRINT
+	);
+
+	exit( $status );
+}
+
+
+/*
+ * Main part begins
+ */
+
+global $argv;
+
+/*
+ * Set up results array, to
+ * be printed on exit.
+ */
+$results = array(
+	'totals' => array(
+		'errors' => 0,
+	),
+
+	'files' => array(
+	),
+);
+
+
+/*
+ * Catch files to scan from $argv.
+ */
+
+$files_to_scan = $argv;
+unset( $files_to_scan[0] );
+
+$files_to_scan = array_values(
+	$files_to_scan
+);
+
+/*
+ * Catch no file specified.
+ */
+
+if ( empty( $files_to_scan ) ) {
+	$results['totals']['errors']++;
+	$results['messages'] = array(
+		array( 'No files to scan specified' ),
+	);
+
+	sysexit(
+		$results,
+		1
+	);
+}
+
+/*
+ * Initialize the SVG scanner.
+ *
+ * Make sure to allow custom attributes,
+ * and to remove remote references.
+ */
+$sanitizer = new enshrined\svgSanitize\Sanitizer();
+
+$sanitizer->setAllowedAttrs(
+	new AllowedAttributesCustom()
+);
+
+$sanitizer->removeRemoteReferences( true );
+
+/*
+ * Scan each file specified to be scanned.
+ */
+
+foreach( $files_to_scan as $file_name ) {
+	/*
+	 * Read SVG file.
+	 */
+	$svg_file = @file_get_contents( $file_name );
+
+	/*
+	 * If not found, report that and continue.
+	 */
+	if ( false === $svg_file ) {
+		$results['totals']['errors']++;
+
+		$results[ 'files' ][ $file_name ][] = array(
+			'status' => false,
+			'issues' => 'File specified could not be read (' . $file_name . ')',
+		);
+
+		continue;
+	}
+
+	/*
+	 * Sanitize file and get issues found.
+	 */
+	$sanitize_status = $sanitizer->sanitize( $svg_file );
+
+	$xml_issues = $sanitizer->getXmlIssues();
+
+	/*
+	 * If we find no issues, simply note that.
+	 */
+	if ( empty( $xml_issues ) && ( false !== $sanitize_status ) ) {
+		$results['files'][ $file_name ] = array(
+			'errors' => 0,
+			'messages' => array()
+		);
+	}
+
+	/*
+	 * If we find issues, note it and update statistics.
+	 */
+
+	else {
+		$results['totals']['errors'] += count( $xml_issues );
+
+		$results['files'][ $file_name ] = array(
+			'errors' => count( $xml_issues ),
+			'messages' => $xml_issues,
+		);
+	}
+
+	unset( $svg_file );
+	unset( $xml_issues );
+	unset( $sanitize_status );
+}
+
+
+/*
+ * Exit with a status
+ * that reflects what issues
+ * we found.
+ */
+sysexit(
+	$results,
+	( $results['totals']['errors'] === 0 ? 0 : 1 )
+);

--- a/tests/SanitizerTest.php
+++ b/tests/SanitizerTest.php
@@ -53,7 +53,8 @@ class SanitizerTest extends TestCase
         $tags = $this->class->getAllowedTags();
 
         $this->assertInternalType('array', $tags);
-        $this->assertEquals(TestAllowedTags::getTags(), $tags);
+
+        $this->assertEquals(array_map('strtolower', TestAllowedTags::getTags()), $tags);
     }
 
     /**
@@ -66,7 +67,8 @@ class SanitizerTest extends TestCase
         $attributes = $this->class->getAllowedAttrs();
 
         $this->assertInternalType('array', $attributes);
-        $this->assertEquals(TestAllowedAttributes::getAttributes(), $attributes);
+
+        $this->assertEquals( array_map('strtolower', TestAllowedAttributes::getAttributes()), $attributes);
     }
 
     /**


### PR DESCRIPTION
This Pull-Request introduces a standalone scanner for the library. It can scan multiple files, specified on the command-line, and output a JSON string just before exiting with the results. 

For instance:

```
$ php svg-scanner.php ~/svgs/myfile.svg 
{
    "totals": {
        "errors": 3
    },
    "files": {
        "\/home\/user\/svgs\/myfile.svg": {
            "errors": 3,
            "messages": [
                {
                    "message": "Suspicious tag 'blabla'",
                    "line": 16
                },
                {
                    "message": "Suspicious tag 'script'",
                    "line": 15
                },
                {
                    "message": "Suspicious attribute 'version'",
                    "line": 2
                }
            ]
        }
    }
}
```

I realise that this code might go outside the scope of the original purpose of the library, and if it is deemed not to fit, that is just fine. I created this for internal purposes and thought it might be good to share it. :-) 


Some of the changes here are duplicates from #24, as this PR depends on that code. 
