### PR TITLE
Use whitelist to fix any issues with scripts/data embeds in href value

### DIFF
--- a/src/Sanitizer.php
+++ b/src/Sanitizer.php
@@ -19,11 +19,6 @@ class Sanitizer
 {
 
     /**
-     * Regex to catch script and data values in attributes
-     */
-    const SCRIPT_REGEX = '/(?:\w+script|data)(?:\s)?:/xi';
-
-    /**
      * @var \DOMDocument
      */
     protected $xmlDocument;
@@ -372,23 +367,12 @@ class Sanitizer
     protected function cleanXlinkHrefs(\DOMElement $element)
     {
         $xlinks = $element->getAttributeNS('http://www.w3.org/1999/xlink', 'href');
-        $xlinks = $this->preFilterHrefValues($xlinks);
-        if (preg_match(self::SCRIPT_REGEX, $xlinks) === 1) {
-            if (!in_array(substr($xlinks, 0, 14), array(
-                'data:image/png', // PNG
-                'data:image/gif', // GIF
-                'data:image/jpg', // JPG
-                'data:image/jpe', // JPEG
-                'data:image/pjp', // PJPEG
-            ))) {
-                $element->removeAttributeNS( 'http://www.w3.org/1999/xlink', 'href' );
-                $this->xmlIssues[] = array(
-                    'message' => 'Suspicious attribute \'href\'',
-                    'line' => $element->getLineNo(),
-                );
-
-
-            }
+        if (false === $this->isHrefSafeValue($xlinks)) {
+            $element->removeAttributeNS( 'http://www.w3.org/1999/xlink', 'href' );
+            $this->xmlIssues[] = array(
+                'message' => 'Suspicious attribute \'href\'',
+                'line' => $element->getLineNo(),
+            );
         }
     }
 
@@ -400,8 +384,7 @@ class Sanitizer
     protected function cleanHrefs(\DOMElement $element)
     {
         $href = $element->getAttribute('href');
-        $href = $this->preFilterHrefValues($href);
-        if (preg_match(self::SCRIPT_REGEX, $href) === 1) {
+        if (false === $this->isHrefSafeValue($href)) {
             $element->removeAttribute('href');
             $this->xmlIssues[] = array(
                 'message' => 'Suspicious attribute \'href\'',
@@ -410,16 +393,49 @@ class Sanitizer
         }
     }
 
-    /**
-     * Only allow basic chars to run through the Script Regex.
-     *
-     * This should stop people from hiding scripts with hidden charachters etc.
-     *
-     * @param $value
-     * @return string|string[]|null
-     */
-    protected function preFilterHrefValues($value) {
-        return preg_replace( '/[^a-zA-Z0-9:\-\(\)\']/', '', $value );
+/**
+ * Only allow whitelisted starts to be within the href.
+ *
+ * This will stop scripts etc from being passed through, with or without attempting to hide bypasses.
+ * This stops the need for us to use a complicated script regex.
+ *
+ * @param $value
+ * @return bool
+ */
+    protected function isHrefSafeValue($value) {
+
+        // Allow fragment identifiers.
+        if ('#' === substr($value, 0, 1)) {
+            return true;
+        }
+
+        // Allow relative URIs.
+        if ('/' === substr($value, 0, 1)) {
+            return true;
+        }
+
+        // Allow HTTPS domains.
+        if ('https://' === substr($value, 0, 8)) {
+            return true;
+        }
+
+        // Allow HTTP domains.
+        if ('http://' === substr($value, 0, 7)) {
+            return true;
+        }
+
+        // Allow known data URIs.
+        if (in_array(substr($value, 0, 14), array(
+            'data:image/png', // PNG
+            'data:image/gif', // GIF
+            'data:image/jpg', // JPG
+            'data:image/jpe', // JPEG
+            'data:image/pjp', // PJPEG
+        ))) {
+           return true;
+        }
+
+        return false;
     }
 
     /**

--- a/src/Sanitizer.php
+++ b/src/Sanitizer.php
@@ -372,6 +372,7 @@ class Sanitizer
     protected function cleanXlinkHrefs(\DOMElement $element)
     {
         $xlinks = $element->getAttributeNS('http://www.w3.org/1999/xlink', 'href');
+        $xlinks = $this->preFilterHrefValues($xlinks);
         if (preg_match(self::SCRIPT_REGEX, $xlinks) === 1) {
             if (!in_array(substr($xlinks, 0, 14), array(
                 'data:image/png', // PNG
@@ -399,6 +400,7 @@ class Sanitizer
     protected function cleanHrefs(\DOMElement $element)
     {
         $href = $element->getAttribute('href');
+        $href = $this->preFilterHrefValues($href);
         if (preg_match(self::SCRIPT_REGEX, $href) === 1) {
             $element->removeAttribute('href');
             $this->xmlIssues[] = array(
@@ -406,6 +408,18 @@ class Sanitizer
                 'line' => $element->getLineNo(),
             );
         }
+    }
+
+    /**
+     * Only allow basic chars to run through the Script Regex.
+     *
+     * This should stop people from hiding scripts with hidden charachters etc.
+     *
+     * @param $value
+     * @return string|string[]|null
+     */
+    protected function preFilterHrefValues($value) {
+        return preg_replace( '/[^a-zA-Z0-9:\-\(\)\']/', '', $value );
     }
 
     /**

--- a/tests/data/hrefCleanOne.svg
+++ b/tests/data/hrefCleanOne.svg
@@ -8,4 +8,5 @@
     <a>test 6</a>
 
     <a>test 7</a>
+    <a>test 8</a>
 </svg>

--- a/tests/data/hrefTestOne.svg
+++ b/tests/data/hrefTestOne.svg
@@ -8,4 +8,5 @@
     <a xlink:href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' onload='alert(88)'%3E%3C/svg%3E">test 6</a>
 
     <a href="javascript&#9;:alert(document.domain)">test 7</a>
+    <a href="javascrip&#9;t:alert('0xd0ff9')">test 8</a>
 </svg>

--- a/tests/data/useClean.svg
+++ b/tests/data/useClean.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 68 65">
     <use xlink:href="#a" x="28" fill="#1A374D"/>
     <path id="a" d="M14 27v-20c0-3.7-3.3-7-7-7s-7 3.3-7 7v41c0 8.2 9.2 17 20 17s20-9.2 20-20c0-13.3-13.4-21.8-26-18zm6 25c-4 0-7-3-7-7s3-7 7-7 7 3 7 7-3 7-7 7z"/>
+    <use />
 </svg>


### PR DESCRIPTION
We were previously using a regex to try and strip scripts from the `href` value by checking for a value starting in `data:` or containing `script:`. After a couple of bypasses were found, we've now locked this down and are only allowing values that start with one of the following: `https://`, `http://`, `/` or `#`. This will fix the issues flagged in #31.