### PR TITLE
Allow empty href values

### DIFF
--- a/src/Sanitizer.php
+++ b/src/Sanitizer.php
@@ -435,6 +435,11 @@ class Sanitizer
  */
     protected function isHrefSafeValue($value) {
 
+        // Allow empty values
+        if (empty($value)) {
+            return true;
+        }
+
         // Allow fragment identifiers.
         if ('#' === substr($value, 0, 1)) {
             return true;


### PR DESCRIPTION
Both [DOMElement::getAttributeNS](https://www.php.net/manual/en/domelement.getattributens.php) and [DOMElement::getAttribute](https://www.php.net/manual/en/domelement.getattribute.php) returns empty strings if no attribute with given name found. This is causing faulty return values in `Sanitizer::getXmlIssues` method.

Fixes #39 