### PR TITLE
[BUGFIX] Allow DOMText and implicitly DOMCdataSection

### DIFF
--- a/tests/SanitizerTest.php
+++ b/tests/SanitizerTest.php
@@ -307,4 +307,20 @@ class SanitizerTest extends TestCase
 
 		self::assertXmlStringEqualsXmlString($expected, $cleanData);
 	}
+
+    /**
+     * @test
+     */
+	public function cdataSectionIsSanitized()
+	{
+		$dataDirectory = __DIR__ . '/data';
+		$initialData = file_get_contents($dataDirectory . '/cdataTest.svg');
+		$expected = file_get_contents($dataDirectory . '/cdataClean.svg');
+
+		$sanitizer = new Sanitizer();
+		$sanitizer->minify(false);
+		$cleanData = $sanitizer->sanitize($initialData);
+
+		self::assertXmlStringEqualsXmlString($expected, $cleanData);
+	}
 }

--- a/tests/data/cdataClean.svg
+++ b/tests/data/cdataClean.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 -1 2 2">
+    <defs><style type="text/css">
+            circle { fill: gold; }
+            other { fill: "&lt;img src onerror=alert(2)&gt;"; }
+            other { fill: '&lt;img src onerror=alert(3)&gt;'; }
+       </style></defs> &lt;img src onerror=alert(4)&gt; and text <text> &lt;img src onerror=alert(5)&gt; and text </text><text> superfluous-but-okay </text><text> math comparison: x&lt;y or y&gt;z </text><text> math comparison: x&lt;y or y&gt;z </text></svg>

--- a/tests/data/cdataTest.svg
+++ b/tests/data/cdataTest.svg
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 -1 2 2">
+    <!--> <img src onerror=alert(1)> and text <!--><![CDATA[]]><![CDATA[ ]]><![CDATA[
+    ]]>
+    <defs>
+        <style type="text/css"><![CDATA[
+            circle { fill: gold; }
+            other { fill: "<img src onerror=alert(2)>"; }
+            other { fill: '<img src onerror=alert(3)>'; }
+       ]]></style>
+    </defs>
+    <![CDATA[ <img src onerror=alert(4)> and text ]]>
+    <text><![CDATA[ <img src onerror=alert(5)> and text ]]></text>
+    <text><![CDATA[ superfluous-but-okay ]]></text>
+    <text><![CDATA[ math comparison: x<y or y>z ]]></text>
+    <text><![CDATA[ math comparison: x<y or y>z ]]></text>
+</svg>

--- a/tests/data/htmlClean.svg
+++ b/tests/data/htmlClean.svg
@@ -1,2 +1,2 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 -1 2 2"></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 -1 2 2"> &gt;&lt;img src onerror=alert(1)&gt;  &gt;&lt;img src onerror=alert(1)&gt; </svg>


### PR DESCRIPTION
Recent change disallowed CDATA sections, however the actual fix
would have been to disallow non SVG-elements when used inline in
some HTML-context.

Resolves: #70