### PR TITLE
Add a little bit more whitespace removal by trimming.

### DIFF
--- a/src/Sanitizer.php
+++ b/src/Sanitizer.php
@@ -226,7 +226,7 @@ class Sanitizer
 
         // Remove any extra whitespaces when minifying
         if ($this->minifyXML) {
-            $clean = preg_replace('/\s+/', ' ', $clean);
+            $clean = trim(preg_replace('/\s+/', ' ', $clean));
         }
 
         // Return result


### PR DESCRIPTION
When a svg with whitespaces or linebreaks at the end is passed those are preserved. I thought it would be better to remove them