### PR TITLE
Fix return typehint for sanitize

### DIFF
--- a/src/Sanitizer.php
+++ b/src/Sanitizer.php
@@ -183,7 +183,7 @@ class Sanitizer
      * Sanitize the passed string
      *
      * @param string $dirty
-     * @return string
+     * @return string|false
      */
     public function sanitize($dirty)
     {


### PR DESCRIPTION
Based on comment in source:

> If we couldn't parse the XML then we go no further. Reset and return false