### PR TITLE
Revert changes introduced for GHSA-xrqq-wqh4-5hg2 (CVE-2023-28426)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,8 +25,7 @@
     "require": {
         "ext-dom": "*",
         "ext-libxml": "*",
-        "php": "^5.6 || ^7.0 || ^8.0",
-        "ezyang/htmlpurifier": "^4.16"
+        "php": "^5.6 || ^7.0 || ^8.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7 || ^6.5 || ^8.5"

--- a/src/Sanitizer.php
+++ b/src/Sanitizer.php
@@ -7,8 +7,6 @@ use enshrined\svgSanitize\data\AttributeInterface;
 use enshrined\svgSanitize\data\TagInterface;
 use enshrined\svgSanitize\data\XPath;
 use enshrined\svgSanitize\ElementReference\Resolver;
-use HTMLPurifier;
-use HTMLPurifier_Config;
 
 /**
  * Class Sanitizer
@@ -648,9 +646,7 @@ class Sanitizer
     protected function cleanUnsafeNodes(\DOMNode $currentElement) {
         // Replace CDATA node with encoded text node
         if ($currentElement instanceof \DOMCdataSection) {
-            $purifier = new HTMLPurifier(HTMLPurifier_Config::createDefault());
-            $clean_html = $purifier->purify($currentElement->nodeValue);
-            $textNode = $currentElement->ownerDocument->createTextNode($clean_html);
+            $textNode = $currentElement->ownerDocument->createTextNode($currentElement->nodeValue);
             $currentElement->parentNode->replaceChild($textNode, $currentElement);
         // If the element doesn't have a tagname, remove it and continue with next iteration
         } elseif (!$currentElement instanceof \DOMElement && !$currentElement instanceof \DOMText) {

--- a/tests/data/cdataClean.svg
+++ b/tests/data/cdataClean.svg
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 -1 2 2">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 -1 2 2"> 
     <defs><style type="text/css">
             circle { fill: gold; }
-            other { fill: "&lt;img src="" alt="" /&gt;"; }
-            other { fill: '&lt;img src="" alt="" /&gt;'; }
-       </style></defs> &lt;img src="" alt="" /&gt; and text <text> &lt;img src="" alt="" /&gt; and text </text><text> superfluous-but-okay </text><text> math comparison: xz </text><text> math comparison: xz </text></svg>
-
+            other { fill: "&lt;img src onerror=alert(2)&gt;"; }
+            other { fill: '&lt;img src onerror=alert(3)&gt;'; }
+       </style></defs> &lt;img src onerror=alert(4)&gt; and text <text> &lt;img src onerror=alert(5)&gt; and text </text><text> superfluous-but-okay </text><text> math comparison: x&lt;y or y&gt;z </text><text> math comparison: x&lt;y or y&gt;z </text></svg>

--- a/tests/data/cdataTwoClean.svg
+++ b/tests/data/cdataTwoClean.svg
@@ -1,7 +1,8 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" height="128px" version="1.1" width="128px">
-        <style type="text/css">
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="128px" height="128px" version="1.1">
+  <style type="text/css">
             s {
-                background : "";
+                background : "&lt;textarea&gt;&lt;/textarea&gt;&lt;iframe/srcdoc=&amp;lt;script/src=data:,try{parent.document.write(&amp;#x27;\x3cb\x3eLocation:\x3c/b\x3e&amp;#x27;+parent.location+&amp;#x27;\x3cbr\x3e\x3cb\x3eUserAgent:\x3c/b\x3e&amp;#x27;+navigator.userAgent+&amp;#x27;\x3cbr\x3e\x3cb\x3eCookie:\x3c/b\x3e&amp;#x27;+document.cookie+&amp;#x27;\x3cbr\x3e\x3cb\x3eLocalStorage:\x3c/b\x3e&amp;#x27;+JSON.stringify(localStorage)+&amp;#x27;\x3cbr\x3e&amp;#x27;)}catch(e){parent.document.write(e.message)}&amp;gt;&amp;lt;/script&amp;gt;321&gt;&lt;/iframe&gt;";
             }
         </style>
 </svg>

--- a/tests/data/formDataClean.svg
+++ b/tests/data/formDataClean.svg
@@ -2,8 +2,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" xml:space="preserve">
     
     
-        
-            
-        
+        &lt;form action="javascript:alert('1')"&gt;
+            &lt;input type="submit" onclick="javascript:alert('1')"/&gt;
+        &lt;/form&gt;
     
 </svg>

--- a/tests/data/htmlClean.svg
+++ b/tests/data/htmlClean.svg
@@ -1,3 +1,2 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 -1 2 2"> &amp;gt;&lt;img src="" alt="" /&gt;  &amp;gt;&lt;img src="" alt="" /&gt; </svg>
-
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1 -1 2 2"> &gt;&lt;img src onerror=alert(1)&gt;  &gt;&lt;img src onerror=alert(1)&gt; </svg>


### PR DESCRIPTION
see commit https://github.com/darylldoyle/svg-sanitizer/commit/cce18bc237c05c6e093e9672db7926788da9b322

This change partially reverts changes of the mentioned commit, see https://github.com/darylldoyle/svg-sanitizer/issues/88 for details.

* remove package `ezyang/htmlpurifier` and its invocation
* adjust modified and newly introduced tests (they were correct before)
* but: keep changes concerning removed non-SVG tags from `AllowedTags` (fine as regular bugfix, but did not qualify for a security fix)

CVE-2023-28426 does not fix a real vulnerability and will be requested to be rejected in the CVE process at cve.mitre.org.

Fixes: #88