### PR TITLE
Preserve libxml errors after failed parsing

### DIFF
--- a/src/Sanitizer.php
+++ b/src/Sanitizer.php
@@ -230,6 +230,7 @@ class Sanitizer
 
         // If we couldn't parse the XML then we go no further. Reset and return false
         if (!$loaded) {
+            $this->xmlIssues = self::getXmlErrors();
             $this->resetAfter();
             return false;
         }
@@ -697,5 +698,22 @@ class Sanitizer
                 $this->cleanUnsafeNodes($childElement);
             }
         }
+    }
+
+    /**
+     * Retrieve array of errors
+     * @return array
+     */
+    private static function getXmlErrors()
+    {
+        $errors = [];
+        foreach (libxml_get_errors() as $error) {
+            $errors[] = [
+                'message' => trim($error->message),
+                'line' => $error->line,
+            ];
+        }
+
+        return $errors;
     }
 }

--- a/tests/SanitizerTest.php
+++ b/tests/SanitizerTest.php
@@ -100,7 +100,20 @@ class SanitizerTest extends TestCase
         $sanitizer = new Sanitizer();
         $cleanData = $sanitizer->sanitize($initialData);
 
-        self::assertSame(false, $cleanData);
+        self::assertFalse($cleanData);
+        self::assertEquals(
+            [
+                [
+                    'message' => 'Opening and ending tag mismatch: line line 8 and svg',
+                    'line' => 15,
+                ],
+                [
+                    'message' => 'Premature end of data in tag svg line 4',
+                    'line' => 16,
+                ],
+            ],
+            $sanitizer->getXmlIssues(),
+        );
     }
 
     /**

--- a/tests/SanitizerTest.php
+++ b/tests/SanitizerTest.php
@@ -112,7 +112,7 @@ class SanitizerTest extends TestCase
                     'line' => 16,
                 ],
             ],
-            $sanitizer->getXmlIssues(),
+            $sanitizer->getXmlIssues()
         );
     }
 


### PR DESCRIPTION
It can be helpful to retrieve parse errors at times.