### PR TITLE
Fix quadratic sanitize time on element-dense SVGs

### DIFF
--- a/src/Sanitizer.php
+++ b/src/Sanitizer.php
@@ -311,12 +311,16 @@ class Sanitizer
      */
     protected function startClean(\DOMNodeList $elements, array $elementsToRemove)
     {
-        // loop through all elements
-        // we do this backwards so we don't skip anything if we delete a node
-        // see comments at: http://php.net/manual/en/class.domnamednodemap.php
-        for ($i = $elements->length - 1; $i >= 0; $i--) {
+        // Iterate over a static snapshot of the list. Calling item($i) on a
+        // live \DOMNodeList while stepping backwards re-walks the underlying
+        // linked list from the start on every call, which makes this loop
+        // O(n²) in the number of child nodes. The snapshot also guarantees
+        // we don't skip any sibling when we delete a node.
+        $currentElements = iterator_to_array($elements, false);
+
+        for ($i = count($currentElements) - 1; $i >= 0; $i--) {
             /** @var \DOMElement $currentElement */
-            $currentElement = $elements->item($i);
+            $currentElement = $currentElements[$i];
 
             /**
              * If the element has exceeded the nesting limit, we should remove it.
@@ -367,12 +371,10 @@ class Sanitizer
                 // Strip out font elements that will break out of foreign content.
                 if (strtolower($currentElement->tagName) === 'font') {
                     $breaksOutOfForeignContent = false;
-                    for ($x = $currentElement->attributes->length - 1; $x >= 0; $x--) {
-                        // get attribute name
-                        $attrName = $currentElement->attributes->item( $x )->nodeName;
-
-                        if (in_array(strtolower($attrName), ['face', 'color', 'size'])) {
+                    foreach ($currentElement->attributes as $attribute) {
+                        if (in_array(strtolower($attribute->nodeName), ['face', 'color', 'size'])) {
                             $breaksOutOfForeignContent = true;
+                            break;
                         }
                     }
 
@@ -402,9 +404,13 @@ class Sanitizer
      */
     protected function cleanAttributesOnWhitelist(\DOMElement $element)
     {
-        for ($x = $element->attributes->length - 1; $x >= 0; $x--) {
+        // Work on a static snapshot: stepping backwards through the live
+        // \DOMNamedNodeMap via item($x) is O(n²) in the number of attributes.
+        $attributes = iterator_to_array($element->attributes, false);
+
+        for ($x = count($attributes) - 1; $x >= 0; $x--) {
             // get attribute name
-            $attrName = $element->attributes->item($x)->nodeName;
+            $attrName = $attributes[$x]->nodeName;
 
             // Remove attribute if not in whitelist
             if (!in_array(strtolower($attrName), $this->allowedAttrs) && !$this->isAriaAttribute(strtolower($attrName)) && !$this->isDataAttribute(strtolower($attrName))) {
@@ -414,6 +420,7 @@ class Sanitizer
                     'message' => 'Suspicious attribute \'' . $attrName . '\'',
                     'line' => $element->getLineNo(),
                 );
+                continue;
             }
 
             /**
@@ -429,13 +436,14 @@ class Sanitizer
                         'message' => 'Suspicious attribute \'href\'',
                         'line'    => $element->getLineNo(),
                     );
+                    continue;
                 }
             }
 
             // Do we want to strip remote references?
             if($this->removeRemoteReferences) {
                 // Remove attribute if it has a remote reference
-                if (isset($element->attributes->item($x)->value) && $this->hasRemoteReference($element->attributes->item($x)->value)) {
+                if (isset($attributes[$x]->value) && $this->hasRemoteReference($attributes[$x]->value)) {
                     $element->removeAttribute($attrName);
                     $this->xmlIssues[] = array(
                         'message' => 'Suspicious attribute \'' . $attrName . '\'',
@@ -719,10 +727,13 @@ class Sanitizer
             return;
         }
 
-        if ( $currentElement->childNodes && $currentElement->childNodes->length > 0 ) {
-            for ($j = $currentElement->childNodes->length - 1; $j >= 0; $j--) {
+        if ($currentElement->hasChildNodes()) {
+            // Same as in startClean(): work on a static snapshot, stepping
+            // backwards through a live \DOMNodeList via item($j) is O(n²).
+            $childNodes = iterator_to_array($currentElement->childNodes, false);
+            for ($j = count($childNodes) - 1; $j >= 0; $j--) {
                 /** @var \DOMElement $childElement */
-                $childElement = $currentElement->childNodes->item($j);
+                $childElement = $childNodes[$j];
                 $this->cleanUnsafeNodes($childElement);
             }
         }

--- a/tests/SanitizerTest.php
+++ b/tests/SanitizerTest.php
@@ -412,4 +412,23 @@ class SanitizerTest extends TestCase
             }
         }
     }
+
+    /**
+     * Test that disallowed nodes interleaved in an element-dense document
+     * are all removed and that no sibling gets skipped along the way.
+     */
+    public function testSanitizeElementDenseSVG()
+    {
+        $count = 500;
+        $initialData = '<svg xmlns="http://www.w3.org/2000/svg">'
+            . str_repeat('<rect x="1" y="1" width="2" height="2"/><script>alert(1)</script>', $count)
+            . '</svg>';
+
+        $sanitizer = new Sanitizer();
+        $cleanData = $sanitizer->sanitize($initialData);
+
+        self::assertSame($count, substr_count($cleanData, '<rect'));
+        self::assertSame(0, substr_count($cleanData, '<script'));
+        self::assertCount($count, $sanitizer->getXmlIssues());
+    }
 }


### PR DESCRIPTION
Found this while profiling SVG handling in a library that uses svg-sanitizer. `sanitize()` gets slow fast on element-dense files, the time looks roughly quadratic in the element count, not linear. So a file well below any byte limit can already cost seconds of CPU.

```php
$svg = '<svg xmlns="http://www.w3.org/2000/svg">'
     . str_repeat('<rect x="1" y="1" width="2" height="2"/>', 10000) . '</svg>';
(new Sanitizer())->sanitize($svg);
```

Measured on my machine (MacBook M4, php 8.5), `sanitize()` alone:

| elements | size   | before  | after |
|----------|--------|---------|-------|
| 1000     | 40 KB  | 8.5 ms  | 5 ms  |
| 5000     | 200 KB | 181 ms  | 25 ms |
| 10000    | 400 KB | 647 ms  | 51 ms |
| 20000    | 800 KB | 2787 ms | 98 ms |

Where the time goes: `startClean()` and `cleanUnsafeNodes()` walk live `DOMNodeList`(s) backwards with `item($i)`. From what I read, the node list cache in PHP only helps forward access, so each backwards `item()` call re-walks the list from the start. A micro benchmark of just that backwards loop on 20000 children takes ~1.3s alone, and it runs twice on the same list. `cleanAttributesOnWhitelist()` has the same pattern on the attributes map.

The fix: snapshot each list into a plain array first (`iterator_to_array`, like cleanHrefAttributes already does), then iterate the array in the same reverse order as before. The `false` argument matters by the way, with preserved keys the attributes are keyed by local name, `href` and `xlink:href` would collide.

About behavior: I ran the whole tests/data corpus plus some crafted files (scripts interleaved between thousands of elements, elements with hundreds of attributes, the use DoS files) through the old and the new code. Byte identical output, identical `getXmlIssues()`, with default config, minify + `removeXMLTag` and `removeRemoteReferences`. Test suite passes. I added a regression test with removable nodes interleaved in a dense document, it asserts on the output, not on timing.

Two caveats I'm aware of. The snapshots add some PHP memory (~65 bytes per node), it only shows on documents with millions of elements, and there the current code is unusable on CPU anyway. And in one corner case (internal DTD declaring a default value for a removed attribute) the old code reported a duplicate xmlIssues entry, the new code doesn't. Output is unchanged in both cases.
