### PR TITLE
Fix href cleaning being skipped when `href` and `xlink:href` coexist

### DIFF
--- a/src/Sanitizer.php
+++ b/src/Sanitizer.php
@@ -479,7 +479,7 @@ class Sanitizer
     protected function cleanHrefAttributes(\DOMElement $element, string $prefix = ''): void
     {
         $relevantAttributes = array_filter(
-            iterator_to_array($element->attributes),
+            iterator_to_array($element->attributes, false),
             static function (\DOMAttr $attr) use ($prefix) {
                 return strtolower($attr->name) === 'href' && strtolower($attr->prefix) === $prefix;
             }

--- a/tests/SanitizerTest.php
+++ b/tests/SanitizerTest.php
@@ -387,6 +387,51 @@ class SanitizerTest extends TestCase
     }
 
     /**
+     * When `href` and `xlink:href` coexist on the same element, both must be
+     * processed by the href cleaning pass: iterating the attribute map by key
+     * collapses them onto the same `href` key, hiding one of the two.
+     *
+     * @test
+     */
+    public function unsafeXlinkHrefIsDetectedWhenPlainHrefCoexists()
+    {
+        $initialData = '<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">'
+            . '<a xlink:href="javascript:alert(1)" href="https://example.com/safe">'
+            . '<text x="10" y="10">x</text></a></svg>';
+
+        $sanitizer = new Sanitizer();
+        $cleanData = $sanitizer->sanitize($initialData);
+
+        self::assertStringNotContainsString('javascript:', $cleanData);
+        self::assertContains(
+            [
+                'message' => 'Suspicious attribute \'xlink:href\'',
+                'line' => 1,
+            ],
+            $sanitizer->getXmlIssues()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function mixedCaseHrefIsNormalizedWhenXlinkHrefCoexists()
+    {
+        $initialData = '<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">'
+            . '<a HREF="#safe" xlink:HREF="#safeTwo">'
+            . '<text x="10" y="10">x</text></a></svg>';
+
+        $expected = '<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">'
+            . '<a href="#safe" xlink:href="#safeTwo">'
+            . '<text x="10" y="10">x</text></a></svg>';
+
+        $sanitizer = new Sanitizer();
+        $cleanData = $sanitizer->sanitize($initialData);
+
+        self::assertXmlStringEqualsXmlString($expected, $cleanData);
+    }
+
+    /**
      * @test
      */
     public function maliciousSvgPhpTagsStripped()


### PR DESCRIPTION
While working on #122, I noticed a tiny bug on `href` and `xlink:href` attributes.

`cleanHrefAttributes()` collects the attributes with `iterator_to_array($element->attributes)`. Without the second argument the entries are keyed by `localName`, and `href` and `xlink:href` share the same localName `href`. So when an element carries both, one silently overwrites the other in the array and never goes through the href cleaning pass.

I don't think this is a sanitization bypass, the shadowed attribute is still caught later by the fallback check in `cleanAttributesOnWhitelist()` (the `stripos` 'href' one), so a `javascript:` value is removed anyway. But you can see it in two places:

- the issue reported by `getXmlIssues()` has the wrong attribute name, `Suspicious attribute 'href'` instead of `Suspicious attribute 'xlink:href'`
- the case normalization is skipped for the shadowed attribute. `<a HREF="#safe" xlink:HREF="#other">` keeps `HREF` as is in the output, it should be lowercased to `href`

Repro for the second one:

```php
$svg = '<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">'
    . '<a HREF="#safe" xlink:HREF="#other"><text x="1" y="1">x</text></a></svg>';
$sanitizer = new \enshrined\svgSanitize\Sanitizer();
echo $sanitizer->sanitize($svg);
// <a HREF="#safe" xlink:href="#other"> ... HREF is not normalized
```

The fix is passing `false` to `iterator_to_array()` so the attributes are collected as a plain list. I added two tests covering both symptoms.
