### PR TITLE
Fix PHP 8.0+ deprecation warning: 'libxml_disable_entity_loader()'

### DIFF
--- a/src/Sanitizer.php
+++ b/src/Sanitizer.php
@@ -294,7 +294,7 @@ class Sanitizer
     {
         // This function has been deprecated in PHP 8.0 because in libxml 2.9.0, external entity loading is
         // disabled by default, so this function is no longer needed to protect against XXE attacks.
-        if (\LIBXML_VERSION < 20900) {
+        if (\LIBXML_VERSION < 20900 && \function_exists('libxml_disable_entity_loader')) {
             // Reset the entity loader
             libxml_disable_entity_loader($this->xmlLoaderValue);
         }

--- a/src/Sanitizer.php
+++ b/src/Sanitizer.php
@@ -274,7 +274,7 @@ class Sanitizer
     {
         // This function has been deprecated in PHP 8.0 because in libxml 2.9.0, external entity loading is
         // disabled by default, so this function is no longer needed to protect against XXE attacks.
-        if (\LIBXML_VERSION < 20900) {
+        if (\LIBXML_VERSION < 20900 && \function_exists('libxml_disable_entity_loader')) {
             // Turn off the entity loader
             $this->xmlLoaderValue = libxml_disable_entity_loader(true);
         }


### PR DESCRIPTION
## What

Added `\function_exists('libxml_disable_entity_loader')` guard to both calls of `libxml_disable_entity_loader()` in `Sanitizer::setUpBefore()` and `Sanitizer::resetAfter()`.

## Why
`libxml_disable_entity_loader()` has been deprecated since PHP 8.0. The existing `\LIBXML_VERSION < 20900` check correctly identifies when the call is *needed* (old libxml without default XXE protection), and in practice PHP 8.0+ always ships with libxml >= 2.9.0, so the branch is never entered at runtime on modern PHP.

However, static analysis tools cannot reason about the runtime relationship between `LIBXML_VERSION` and PHP version - they see the deprecated function call as reachable and report warning.

Adding `function_exists()` makes the guard explicit for *Static analyzers* and if the function will be removed in future PHP version, the code won't produce a fatal error.

Using `function_exists()` is preferred over a `PHP_VERSION_ID` check because it can tests actual runtime capability rather than relying on version assumptions that may vary across builds and distributions.

## Where 

- `src/Sanitizer.php` - `setUpBefore()` method (line ~279)
- `src/Sanitizer.php` - `resetAfter()` method (line ~299)