### PR TITLE
Fix/case sensitive href

### DIFF
--- a/src/ElementReference/Resolver.php
+++ b/src/ElementReference/Resolver.php
@@ -96,10 +96,15 @@ class Resolver
      */
     protected function processReferences()
     {
+        // Note: the href attribute is deliberately not filtered in the XPath predicate.
+        // XPath attribute matching is case sensitive, so `[@href or @xlink:href]` would
+        // skip `<use HrEf="#id">`/`<use xlink:HrEf="#id">` - names that
+        // `Sanitizer::cleanHrefAttributes()` normalizes back to `href`/`xlink:href`
+        // afterwards, which would hand back a live reference the graph never saw.
         $useNodeName = $this->xPath->createNodeName('use');
         foreach ($this->subjects as $subject) {
             $useElements = $this->xPath->query(
-                $useNodeName . '[@href or @xlink:href]',
+                $useNodeName,
                 $subject->getElement()
             );
 

--- a/src/Helper.php
+++ b/src/Helper.php
@@ -3,7 +3,17 @@ namespace enshrined\svgSanitize;
 
 class Helper
 {
+    const XLINK_NAMESPACE_URI = 'http://www.w3.org/1999/xlink';
+
     /**
+     * Resolves the `href`/`xlink:href` value of an element.
+     *
+     * The lookup is case insensitive on purpose: `Sanitizer::cleanHrefAttributes()`
+     * normalizes names such as `HrEf`/`xlink:HrEf` back to `href`/`xlink:href`,
+     * so anything consuming this helper has to see those attributes as well -
+     * otherwise a mixed-case name hides the reference from e.g. the `<use>`
+     * reference graph, which is built before that normalization happens.
+     *
      * @param \DOMElement $element
      * @return string|null
      */
@@ -12,8 +22,19 @@ class Helper
         if ($element->hasAttribute('href')) {
             return $element->getAttribute('href');
         }
-        if ($element->hasAttributeNS('http://www.w3.org/1999/xlink', 'href')) {
-            return $element->getAttributeNS('http://www.w3.org/1999/xlink', 'href');
+        if ($element->hasAttributeNS(self::XLINK_NAMESPACE_URI, 'href')) {
+            return $element->getAttributeNS(self::XLINK_NAMESPACE_URI, 'href');
+        }
+        foreach ($element->attributes as $attribute) {
+            if (!$attribute instanceof \DOMAttr
+                || strtolower($attribute->localName) !== 'href'
+            ) {
+                continue;
+            }
+            $prefix = strtolower((string)$attribute->prefix);
+            if ($prefix === '' || $prefix === 'xlink') {
+                return $attribute->value;
+            }
         }
         return null;
     }

--- a/tests/SanitizerTest.php
+++ b/tests/SanitizerTest.php
@@ -348,7 +348,10 @@ class SanitizerTest extends TestCase
         $sanitizer->minify(false);
         $cleanData = $sanitizer->sanitize($initialData);
 
-        self::assertStringNotContainsString('<use', $cleanData);
+        // Plain string/regex checks rather than PHPUnit's string constraints: the
+        // matrix runs PHPUnit 6.5 on PHP 7.1 and 8.5 everywhere else, and the
+        // relevant assertions do not exist across that whole range.
+        self::assertSame(0, substr_count($cleanData, '<use'));
         self::assertXmlStringEqualsXmlString($expected, $cleanData);
     }
 
@@ -400,7 +403,7 @@ class SanitizerTest extends TestCase
         $sanitizer->minify(false);
         $cleanData = $sanitizer->sanitize($initialData);
 
-        self::assertNotRegExp('/<use[^>]*href/i', $cleanData);
+        self::assertSame(0, preg_match('/<use[^>]*href/i', $cleanData));
     }
 
     public function testInvalidNodesAreHandled()

--- a/tests/SanitizerTest.php
+++ b/tests/SanitizerTest.php
@@ -308,6 +308,101 @@ class SanitizerTest extends TestCase
         self::assertXmlStringEqualsXmlString($expected, $cleanData);
     }
 
+    /**
+     * Attribute names that `Sanitizer::cleanHrefAttributes()` normalizes, paired with
+     * the canonical name they are normalized to.
+     *
+     * @return array<string, array{0: string, 1: string}>
+     */
+    public static function mixedCaseHrefAttributeNameDataProvider()
+    {
+        return [
+            'xlink:HrEf' => ['xlink:HrEf', 'xlink:href'],
+            'xlink:HREF' => ['xlink:HREF', 'xlink:href'],
+            'href' => ['href', 'href'],
+            'HrEf' => ['HrEf', 'href'],
+            'HREF' => ['HREF', 'href'],
+        ];
+    }
+
+    /**
+     * The `<use>` reference graph is built before `cleanHrefAttributes()` normalizes
+     * names such as `xlink:HrEf` back to `xlink:href`. Selecting the referencing
+     * elements case sensitively therefore used to hide the whole nesting bomb from
+     * the graph, and the sanitizer handed it back intact with canonical attributes.
+     *
+     * @test
+     * @dataProvider mixedCaseHrefAttributeNameDataProvider
+     */
+    public function useDOSattacksAreNullifiedForMixedCaseHrefAttributes($attributeName, $canonicalName)
+    {
+        $dataDirectory = __DIR__ . '/data';
+        $initialData = str_replace(
+            'xlink:href',
+            $attributeName,
+            file_get_contents($dataDirectory . '/useDosTest.svg')
+        );
+        $expected = file_get_contents($dataDirectory . '/useDosClean.svg');
+
+        $sanitizer = new Sanitizer();
+        $sanitizer->minify(false);
+        $cleanData = $sanitizer->sanitize($initialData);
+
+        self::assertStringNotContainsString('<use', $cleanData);
+        self::assertXmlStringEqualsXmlString($expected, $cleanData);
+    }
+
+    /**
+     * Same as above for the `useThreshold` machinery, which counts uses on the
+     * very same reference graph.
+     *
+     * @test
+     * @dataProvider mixedCaseHrefAttributeNameDataProvider
+     */
+    public function useRecursionsAreDetectedForMixedCaseHrefAttributes($attributeName, $canonicalName)
+    {
+        $dataDirectory = __DIR__ . '/data';
+        $initialData = str_replace(
+            'xlink:href',
+            $attributeName,
+            file_get_contents($dataDirectory . '/xlinkLaughsTest.svg')
+        );
+        $expected = str_replace(
+            'xlink:href',
+            $canonicalName,
+            file_get_contents($dataDirectory . '/xlinkLaughsClean.svg')
+        );
+
+        $sanitizer = new Sanitizer();
+        $sanitizer->minify(false);
+        $cleanData = $sanitizer->sanitize($initialData);
+
+        self::assertXmlStringEqualsXmlString($expected, $cleanData);
+    }
+
+    /**
+     * A mixed-case *prefix* (`XLINK:href`) is not bound to the xlink namespace, so the
+     * attribute is dropped wholesale by `cleanXlinkHrefs()`. The `<use>` elements survive
+     * as leftovers, but without an href they reference nothing and expand to nothing.
+     *
+     * @test
+     */
+    public function useElementsWithUnboundHrefPrefixLoseTheirReference()
+    {
+        $dataDirectory = __DIR__ . '/data';
+        $initialData = str_replace(
+            'xlink:href',
+            'XLINK:href',
+            file_get_contents($dataDirectory . '/useDosTest.svg')
+        );
+
+        $sanitizer = new Sanitizer();
+        $sanitizer->minify(false);
+        $cleanData = $sanitizer->sanitize($initialData);
+
+        self::assertNotRegExp('/<use[^>]*href/i', $cleanData);
+    }
+
     public function testInvalidNodesAreHandled()
     {
         $dataDirectory = __DIR__ . '/data';


### PR DESCRIPTION
This pull request improves the handling of mixed-case `href` and `xlink:href` attributes in SVG sanitization and reference resolution. The main focus is to ensure that references using different casings of these attributes are correctly identified and sanitized, preventing security bypasses and ensuring consistent behavior. The changes also introduce comprehensive tests to cover these scenarios.

**Improvements to reference resolution and attribute handling:**

* Updated the XPath query in `Resolver.php` to select all `<use>` elements regardless of `href` attribute casing, ensuring references with mixed-case attribute names are not missed before normalization.
* Enhanced the `Helper::getElementHref()` method to resolve `href`/`xlink:href` attributes in a case-insensitive manner, including those with mixed-case names and prefixes, preventing hidden references due to case mismatches. [[1]](diffhunk://#diff-6ac188236546e8e160a96ba97849a9a9b8029ecb472fb728d4b305e0e50be2cfR6-R16) [[2]](diffhunk://#diff-6ac188236546e8e160a96ba97849a9a9b8029ecb472fb728d4b305e0e50be2cfL15-R37)

**Testing and validation:**

* Added new test cases in `SanitizerTest.php` to verify that mixed-case `href` and `xlink:href` attributes are normalized and sanitized correctly, including:
  - Data provider for mixed-case attribute names.
  - Tests to ensure DOS attacks and recursion via mixed-case attributes are nullified.
  - Tests to verify that unbound prefix attributes (e.g., `XLINK:href`) are dropped and do not create references.